### PR TITLE
Animation Export Error Fix & Negative Emitter Mass

### DIFF
--- a/neverblender/nvb_animnode.py
+++ b/neverblender/nvb_animnode.py
@@ -416,7 +416,9 @@ class Animnode():
                 Animnode.emitter_properties.items():
             exports.append([aur_name, dp_dim, aur_fstr, dp, dp_dim])
         # Get keyframe data
-        all_fcurves = action.fcurves
+        all_fcurves = getattr(action, 'fcurves', None)
+        if all_fcurves is None:
+            return
         for aur_name, aur_dim, aur_fstr, dp, dp_dim in exports:
             fcu = [all_fcurves.find(data_path=dp, index=i)
                    for i in range(dp_dim)]
@@ -473,7 +475,9 @@ class Animnode():
         # List of exportable data paths with formats and conversion functions
         exports = get_exports(action, blend_mat_out)
         # Get keyframe data
-        all_fcurves = action.fcurves
+        all_fcurves = getattr(action, 'fcurves', None)
+        if all_fcurves is None:
+            return
         for aur_name, aur_dim, aur_fstr, dp, dp_dim, _, \
                 default_val in exports:
             fcu = [all_fcurves.find(data_path=dp, index=i)
@@ -563,7 +567,9 @@ class Animnode():
         # List of exportable data paths with formats and conversion functions
         exports = get_exports(obj.rotation_mode)
         # Get keyframe data
-        all_fcurves = action.fcurves
+        all_fcurves = getattr(action, 'fcurves', None)
+        if all_fcurves is None:
+            return
         for aur_name, aur_dim, aur_fstr, dp, dp_dim, dp_conversion, \
                 default_val in exports:
             fcu = [all_fcurves.find(data_path=dp, index=i)

--- a/neverblender/nvb_node.py
+++ b/neverblender/nvb_node.py
@@ -1027,7 +1027,7 @@ class Emitter(Node):
          'renderorder': ('nvb.renderorder', 1, nvb_utils.str2int, ' {:1.0f}'),
          'birthrate': ('nvb.birthrate', 1, nvb_utils.str2int, ' {:1.0f}'),
          'lifeexp': ('nvb.lifeexp', 1, float, ' {: >3.2f}'),
-         'mass': ('mass', 1, float, ' {: >3.2f}'),
+         'mass': ('nvb.mass', 1, float, ' {: >3.2f}'),
          'velocity': ('normal_factor', 1, float, ' {:>4.2f}'),
          'randvel': ('factor_random', 1, float, ' {:>4.2f}'),
          'particlerot': ('angular_velocity_factor', 1, float, ' {:>4.2f}'),
@@ -1200,7 +1200,7 @@ class Emitter(Node):
         # Particle properties
         ascii_lines.append(form_prop('birthrate', part_set.nvb.birthrate))
         ascii_lines.append(form_prop('lifeexp', part_set.nvb.lifeexp))
-        ascii_lines.append(form_prop('mass', part_set.mass))
+        ascii_lines.append(form_prop('mass', part_set.nvb.mass))
         ascii_lines.append(form_prop('velocity', part_set.normal_factor))
         ascii_lines.append(form_prop('randvel', part_set.factor_random))
         ascii_lines.append(form_prop('particlerot',

--- a/neverblender/nvb_props.py
+++ b/neverblender/nvb_props.py
@@ -465,13 +465,17 @@ class NVB_PG_emitter(bpy.types.PropertyGroup):
                                      default=1, min=0)
     lifeexp: bpy.props.FloatProperty(name='Life Exp.', subtype='TIME',
                                      default=0.0, min=-1.0)
-    # mass => from blender ".mass"
+    mass: bpy.props.FloatProperty(
+        name='Mass',
+        description='Weight of the particles, \
+		             Negative numbers make the particles float up',
+        default=0.0)
     # velocity => from blender ".normal_factor"
     # randvel => from blender ".factor_random"
     # particleRot => from blender ".angular_velocity_factor"
     spread: bpy.props.FloatProperty(
         name='Spread',
-        description='Prticle spread angle for Fountain type emitters',
+        description='Particle spread angle for Fountain type emitters',
         subtype='ANGLE', unit='ROTATION',
         default=0.0, min=0.0, soft_max=6.29)
     splat: bpy.props.BoolProperty(

--- a/neverblender/nvb_ui.py
+++ b/neverblender/nvb_ui.py
@@ -884,7 +884,7 @@ class NVB_PT_emitter(bpy.types.Panel):
         col.prop(part_settings.nvb, "birthrate")
         col.prop(part_settings.nvb, "lifeexp")
         col.prop(part_settings.nvb, "spread")
-        col.prop(part_settings, "mass")
+        col.prop(part_settings.nvb, "mass")
         col = split.column()
         col.prop(part_settings, "normal_factor", text="Velocity")
         col.prop(part_settings, "factor_random", text="Rand. Velocity")


### PR DESCRIPTION
- Fixes a fatal error when exporting a mdl that has an animation action but no fcurves, which can happen if you delete all your keyframes from an animation.
- Use custom emitter mass property instead of blender's partical mass to allow for negative emitter mass values.